### PR TITLE
Revert "Fixed year typo at the end of README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This reverts commit `1821cef7aa34d6da9bd6c9986c81a837c2e67768`, where the year at the end of `README.md` was changed from 2022 to 2023.